### PR TITLE
fix: let video overlay resize naturally. Closes #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -2170,10 +2170,6 @@
           $('#video-overlay').hide(); // Hide the overlay
         } else {
           $('#videos')[0].pause();
-          $('#video-overlay').css({
-            'width': $('#videos').width(),
-            'height': $('#videos').height()
-          });
           $('#video-overlay').stop(); //Stop animation (not sure why this is animated?)
           $('#video-overlay').show(); //Show the overlay and adjust its w and h
           trackEvent('button_click', { //GA tracking of video plays


### PR DESCRIPTION

- Lets the video-overlay resize naturally. No need to try and programatically set the width and height, since the overlay already has a rule set to take up 100% of it's container width and height

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/ff547979-5d5f-41f0-9e1d-ce0ec76633a4" />

<img width="793" alt="image" src="https://github.com/user-attachments/assets/7bd04136-72b9-4e0d-a151-ffb8c42cf454" />

<img width="509" alt="image" src="https://github.com/user-attachments/assets/4bdc1b73-3cd6-4598-806e-31f9292765f2" />
