### PR TITLE
fix: call handleNavigation on mobile menu item click

### DIFF
--- a/scripts/mobile-navigation.js
+++ b/scripts/mobile-navigation.js
@@ -182,8 +182,11 @@ $(document).ready(function () {
     }
   }
 
-  // When an item on with an href value that starts with a "#" close the navigation and scroll to that section
-  $mobileNavContainer.on("click", handleNavigation);
+  // Attach a click handler to each link element in the mobile nav
+  $mobileNav.find('li.menu-item > a').on('click', function(event) {
+    handleNavigation(event);
+  });
+  
   $mobileNavContainer.on("keydown", function (event) {
     if (["Enter"].includes(event.key)) {
       handleNavigation(event);


### PR DESCRIPTION

- Fixes a problem where click event were not being registered on the mobile nav item clicks. When the keyboard navigation was enabled via #19 it broke the click handler in the mobile menu navigation